### PR TITLE
Refactor .coderabbit.yaml to nest docstrings under finishing_touches

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,5 +3,6 @@ reviews:
     auto_review:
         enabled: true
         drafts: false
-    docstrings:
-        enabled: false # docstrings生成を完全に無効化
+    finishing_touches:
+        docstrings:
+            enabled: false # docstrings生成を完全に無効化


### PR DESCRIPTION
## Summary
Reorganizes the CodeRabbit configuration by moving docstrings settings under the `finishing_touches` section for better structure and clarity.

## Changes
- Nested `docstrings` configuration under `finishing_touches`
- Improved YAML structure and organization
- No functional changes to the actual settings

## Benefits
- More logical configuration hierarchy
- Easier to maintain and understand
- Aligns with CodeRabbit's recommended structure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal configuration reorganization completed with no impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->